### PR TITLE
fix(95): pressure rings

### DIFF
--- a/2D SPH/Assets/Shaders/Pressure.hlsl
+++ b/2D SPH/Assets/Shaders/Pressure.hlsl
@@ -6,7 +6,7 @@ float restDensity;
 float2 PressureKernelGrad(float2 offset) {
     float r = length(offset);
     
-    if (r < 0.0001 || r > smoothingRadius)
+    if (r < 1e-6 || r > smoothingRadius)
         return float2(0, 0);
     
     float inner = smoothingRadius - r;

--- a/2D SPH/Assets/Shaders/Viscosity.hlsl
+++ b/2D SPH/Assets/Shaders/Viscosity.hlsl
@@ -5,7 +5,7 @@ float viscosityMultiplier;
 float ViscosityKernelLap(float2 offset) {
     float r = length(offset);
 
-    if (r < 0.0001 || r > smoothingRadius)
+    if (r > smoothingRadius)
         return 0;
 
     return viscosityKernelLapConstant * (smoothingRadius - r);


### PR DESCRIPTION
Closes #95 

I was ignoring pressures for "very" close particles so that there weren't any approaching infinity bugs. Turns out my definition of "very" was not "very" enough. Changing epsilon from 0.001 -> 0.000001 fixed the rings in one fell swoop. Feels good man.