### PR TITLE
fix(108): acceleration leakage

### DIFF
--- a/2D SPH/Assets/Scripts/ShaderHelper.cs
+++ b/2D SPH/Assets/Scripts/ShaderHelper.cs
@@ -24,6 +24,8 @@ class ShaderHelper
     ComputeBuffer velocityBufferA;
     ComputeBuffer velocityBufferB;
     ComputeBuffer accelerationBuffer;
+    ComputeBuffer accelerationBufferA;
+    ComputeBuffer accelerationBufferB;
     ComputeBuffer densityBuffer;
 
     // Maps
@@ -64,6 +66,8 @@ class ShaderHelper
         nameBufferMap.Add("Velocities", velocityBuffer);
         nameBufferMap.Add("Positions", positionBuffer);
 
+        nameBufferMap.Add("OldAccelerations", accelerationBuffer);
+        nameBufferMap.Add("NewAccelerations", (accelerationBuffer == accelerationBufferA) ? accelerationBufferB : accelerationBufferA);
         nameBufferMap.Add("OldVelocities", velocityBuffer);
         nameBufferMap.Add("NewVelocities", (velocityBuffer == velocityBufferA) ? velocityBufferB : velocityBufferA);
         nameBufferMap.Add("OldPositions", positionBuffer);
@@ -112,7 +116,8 @@ class ShaderHelper
         kernelStaticBufferMap.Add(positionKernel, new string[] { "Accelerations" });
 
         kernelDynamicBufferMap.Add(partitionKernel, new string[] { "Positions" });
-        kernelDynamicBufferMap.Add(scatterKernel, new string[] { "OldVelocities", "NewVelocities",
+        kernelDynamicBufferMap.Add(scatterKernel, new string[] { "OldAccelerations", "NewAccelerations",
+                                                                 "OldVelocities", "NewVelocities",
                                                                  "OldPositions", "NewPositions" });
         kernelDynamicBufferMap.Add(densityKernel, new string[] { "Densities", "Positions" });
         kernelDynamicBufferMap.Add(accelerationKernel, new string[] { "Densities", "Velocities", "Positions" });
@@ -164,7 +169,10 @@ class ShaderHelper
 
         velocityBuffer = velocityBufferA;
 
-        accelerationBuffer = new ComputeBuffer(instanceCount, sizeof(float) * 2);
+        accelerationBufferA = new ComputeBuffer(instanceCount, sizeof(float) * 2);
+        accelerationBufferB = new ComputeBuffer(instanceCount, sizeof(float) * 2);
+
+        accelerationBuffer = accelerationBufferA;
 
         densityBuffer = new ComputeBuffer(instanceCount, sizeof(float));
 
@@ -175,10 +183,12 @@ class ShaderHelper
     {
         positionBuffer = (positionBuffer == positionBufferA) ? positionBufferB : positionBufferA;
         velocityBuffer = (velocityBuffer == velocityBufferA) ? velocityBufferB : velocityBufferA;
+        accelerationBuffer = accelerationBuffer == accelerationBufferA ? accelerationBufferB : accelerationBufferA;
 
         // Update mappings
         nameBufferMap["Positions"] = positionBuffer;
         nameBufferMap["Velocities"] = velocityBuffer;
+        nameBufferMap["Accelerations"] = accelerationBuffer;
 
         // Swap Old/New mappings
         nameBufferMap["OldPositions"] = positionBuffer;
@@ -186,6 +196,9 @@ class ShaderHelper
 
         nameBufferMap["OldVelocities"] = velocityBuffer;
         nameBufferMap["NewVelocities"] = (velocityBuffer == velocityBufferA) ? velocityBufferB : velocityBufferA;
+
+        nameBufferMap["OldAccelerations"] = accelerationBuffer;
+        nameBufferMap["NewAccelerations"] = (accelerationBuffer == accelerationBufferA) ? accelerationBufferB : accelerationBufferA;
     }
 
 
@@ -223,8 +236,10 @@ class ShaderHelper
             positionBufferB.Release();
         if (velocityBufferB != null)
             velocityBufferB.Release();
-        if (accelerationBuffer != null)
-            accelerationBuffer.Release();
+        if (accelerationBufferA != null)
+            accelerationBufferA.Release();
+        if (accelerationBufferB != null)
+            accelerationBufferB.Release();
         if (densityBuffer != null)
             densityBuffer.Release();
     }

--- a/2D SPH/Assets/Shaders/Particle.compute
+++ b/2D SPH/Assets/Shaders/Particle.compute
@@ -29,7 +29,6 @@ RWStructuredBuffer<float> Densities;
 RWStructuredBuffer<float2> Positions;
 RWStructuredBuffer<float2> Velocities;
 RWStructuredBuffer<float2> Accelerations;
-RWStructuredBuffer<float2> OldAccelerations;
 
 // Integers
 uint instanceCount;

--- a/2D SPH/Assets/Shaders/Scatter.hlsl
+++ b/2D SPH/Assets/Shaders/Scatter.hlsl
@@ -4,6 +4,9 @@ RWStructuredBuffer<float2> NewPositions;
 RWStructuredBuffer<float2> OldVelocities;
 RWStructuredBuffer<float2> NewVelocities;
 
+RWStructuredBuffer<float2> OldAccelerations;
+RWStructuredBuffer<float2> NewAccelerations;
+
 void SortParticle(uint i)
 {
     
@@ -19,4 +22,5 @@ void SortParticle(uint i)
 
     NewPositions[destIndex]  = OldPositions[i];
     NewVelocities[destIndex] = OldVelocities[i];
+    NewAccelerations[destIndex] = OldAccelerations[i];
 }


### PR DESCRIPTION
Closes #108 

SO:

Accelerations were leaking between particles, how is that possible I hear you asking. Here's how:

1. Scatter positions/velocities into bin-contiguous order
2. Calculate density and accelerations
3. Update positions from density/acceleration, this will UNSORT them
4. No worries, re-scatter positions/velocities
5. Now we need to update velocities with the old acceleration (stored in the buffer from step 2) and the new acceleration (calculated directly from current state)
6. BUT the old accelerations from step 2 are now out of order as we re-scattered in step 4

So we need to double buffer acceleration and scatter it in that kernel to preserve consistent ordering. That's what this PR does
