### PR TITLE
feat(163): back to physical viscosity

### DIFF
--- a/2D SPH/Assets/Scenes/TestScene.unity
+++ b/2D SPH/Assets/Scenes/TestScene.unity
@@ -301,8 +301,8 @@ MonoBehaviour:
   dampingFactor: 0.95
   restDensity: 3
   relaxationFactor: 0.5
-  viscosityMultiplier: 0
-  surfaceTensionMultiplier: 0
+  viscosityMultiplier: 0.08
+  surfaceTensionMultiplier: 0.1
 --- !u!4 &1274155412
 Transform:
   m_ObjectHideFlags: 0
@@ -331,11 +331,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 90a21f46cb45640b88337bf5d5a09f85, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Spawn
-  instanceCount: 39216
+  instanceCount: 20553
   size: 0.2
   spacing: 0
-  spawnArea: {x: 45.8, y: 34.57}
-  spawnPosition: {x: 0, y: -1.6}
+  spawnArea: {x: 44.3, y: 18.6}
+  spawnPosition: {x: 0, y: -8.99}
   asGrid: 1
 --- !u!114 &1274155414
 MonoBehaviour:

--- a/2D SPH/Assets/Scripts/Spawn.cs
+++ b/2D SPH/Assets/Scripts/Spawn.cs
@@ -181,6 +181,9 @@ public class Spawn : MonoBehaviour
                     x * sizeWithSpacing,
                     -y * sizeWithSpacing
                 );
+
+                // Add tiny offset so things don't stack
+                positions[idx] += new Vector2(Random.Range(-0.05f, 0.05f), Random.Range(-0.05f, 0.05f));
             }
         }
 

--- a/2D SPH/Assets/Shaders/Viscosity.hlsl
+++ b/2D SPH/Assets/Shaders/Viscosity.hlsl
@@ -5,20 +5,16 @@ float viscosityMultiplier;
 float2 CalculateViscosityContribution(uint i, uint j) {
     float2 posOffset = Positions[i] - Positions[j];
     float2 velOffset = Velocities[i] - Velocities[j];
+    float r = length(posOffset);
 
-    float velPosDot = dot(velOffset, posOffset);
+    if (r < 1e-6) return float2(0, 0);
 
-    if (velPosDot >= 0) return float2(0, 0);
-
+    // Physical viscosity - always acts on velocity differences
     float2 gradient = CubicSplineGrad(posOffset);
 
-    float viscosityCoefficient = viscosityMultiplier * smoothingRadius / (Densities[i] + Densities[j]);
-    
-    float numerator = viscosityCoefficient * velPosDot;
+    // Viscous force: ν * m_j * (v_i - v_j) / ρ_j * ∇W
+    float viscosity = viscosityMultiplier; // Now directly the kinematic viscosity
 
-    float posOffsetSq = dot(posOffset, posOffset);
-    float epsilon = 0.01;
-    float denominator = posOffsetSq + epsilon * smoothingRadius * smoothingRadius;
-
-    return particleMass * (numerator / denominator) * gradient;
+    return 2.0 * viscosity * particleMass * velOffset * dot(posOffset, gradient) /
+            (Densities[j] * (dot(posOffset, posOffset) + 0.01 * smoothingRadius * smoothingRadius));
 }


### PR DESCRIPTION
Closes #163 

ST was working fine.
WCSPH used artificial viscosity that was helping stability but is boring. Replaced with good-old physical viscosity, it's more fun and the sim is stable enough