### PR TITLE
fix(214): lag at lower sim speeds

### DIFF
--- a/2D SPH/Assets/Scripts/Simulate.cs
+++ b/2D SPH/Assets/Scripts/Simulate.cs
@@ -84,7 +84,6 @@ public class Simulate : MonoBehaviour
 
         if (started)
         {
-            UpdateWaveForce();
             AdvanceFrame();
         }
 
@@ -101,6 +100,7 @@ public class Simulate : MonoBehaviour
 
     void AdvanceFrame()
     {
+        UpdateWaveForce();
         accumulator += Time.deltaTime;
 
         int stepsThisFrame = 0;
@@ -336,8 +336,10 @@ public class Simulate : MonoBehaviour
         {
             if (simulationSpeed != 0) return;
             simulationSpeed = 1;
+            UpdateVariables();
             for (int _ = 0; _ < stepSize; _++) AdvanceFrame();
             simulationSpeed = 0;
+            UpdateVariables();
         }
 
         HandleSpeedControls();


### PR DESCRIPTION
Closes #214

Fairly trivial fix, just have to enforce `deltaTime` synchronisation on GPU.
This PR also fixes the frame stepping that was broken for the same reason (who knew)