### PR TITLE
fix(219): WCSPH sim pausing

### DIFF
--- a/2D SPH/Assets/Shaders/WCSPH.hlsl
+++ b/2D SPH/Assets/Shaders/WCSPH.hlsl
@@ -41,6 +41,7 @@ void CalculateWCSPHComponents(uint i, out float3 viscosity, out float3 surfaceTe
 }
 
 float3 CalculateAcceleration(int i) {
+    if (deltaTime == 0) return 0;
     float3 viscosity;
     float3 surfaceTension;
     float3 pressure;


### PR DESCRIPTION
Closes #219 

WCSPH was breaking when I paused.

Forgot I was dividing XPH by `deltaTime` to make it a velocity update, obviously this is bad if `deltaTime` is 0 when sim is paused. One-liner.