### PR TITLE
feat(317): refraction infrastructure

### DIFF
--- a/2D SPH/Assets/Shaders/Density.hlsl
+++ b/2D SPH/Assets/Shaders/Density.hlsl
@@ -42,7 +42,7 @@ float CalculateDensityAtWorld(float3 pos) {
         for (uint j = startIndex; j < endIndex; j++) {
             float3 offset = pos - Positions[j];
             float r = length(offset);
-            density += particleMass * CubicSplineKernel(r, smoothingRadius * 1.2);
+            density += particleMass * CubicSplineKernel(r);
         }
     }
 

--- a/2D SPH/Assets/Shaders/Kernels.hlsl
+++ b/2D SPH/Assets/Shaders/Kernels.hlsl
@@ -16,21 +16,6 @@ float CubicSplineKernel(float r) {
     return kernelConstant * result;
 }
 
-float CubicSplineKernel(float r, float smoothingRadius) {
-    float q = r / smoothingRadius;
-
-    if (isnan(q) || q >= 2 || r < Epsilon) return 0;
-
-    float result;
-    if (q >= 1) {
-        result = 0.25 * pow(2 - q, 3);
-    } else {
-        result = (1 - 1.5 * q * q + 0.75 * q * q * q);
-    }
-
-    return kernelConstant * result;
-}
-
 float3 CubicSplineGrad(float3 offset, float r) {
     float q = r / smoothingRadius;
     if (q >= 2 || isnan(q) || r < Epsilon) return float3(0, 0, 0);

--- a/2D SPH/Assets/Shaders/Rays.shader
+++ b/2D SPH/Assets/Shaders/Rays.shader
@@ -29,7 +29,7 @@
               float sunIntensity;
               float densityThreshold;
 
-              static const float fluidStepSize = 0.01;
+              static const float fluidStepSize = 0.005;
               static const float lightStepSize = 0.2;
               static const int maxSteps = 256;
 
@@ -95,7 +95,7 @@
                 for (int _ = 0; _ < maxSteps; _++) {
                     if (any(rayLoc < 0) || any(rayLoc > 1)) break;
 
-                    totalDensity += SampleDensity(rayLoc);
+                    totalDensity += SampleDensity(rayLoc) * rayStepSize * densityMultiplier;
 
                     rayLoc += rayDir * rayStepSize;
                 }


### PR DESCRIPTION
Closes #317 

I've written a couple of utility functions that can find next surface (be it entry or exit), tracks density along the ray if it's travelling through the fluid, and calculates the density along a non-view ray (i.e. light ray).

It's working for one refraction, but obviously we get artifacts, consider:

1. Ray enters fluid at grazing angle
2. Briefly travels through liquid, then exits again
3. Hence low density total -> high transmittance
4. Stops here after the first refraction, high transmittance means low opacity and it returns the environment + sun light
5. Hence the current white bands we're getting

Can be solved in next issue when we add multiple refractions!