### PR TITLE
fix(367): Broken rays on resolution change

### DIFF
--- a/2D SPH/Assets/Scripts/Core/Rendering/Rays.cs
+++ b/2D SPH/Assets/Scripts/Core/Rendering/Rays.cs
@@ -18,13 +18,9 @@ public class Rays
         this.cube.GetComponent<Renderer>().material = mat;
     }
 
-    public void BindTexture(RenderTexture densityTex)
+    public void RenderToCube(RenderTexture densityTex, float densityThreshold)
     {
         mat.SetTexture("DensityTex", densityTex);
-    }
-
-    public void RenderToCube(float densityThreshold)
-    {
         mat.SetFloat("densityThreshold", densityThreshold);
         cube.SetActive(true);
     }

--- a/2D SPH/Assets/Scripts/Runtime/Draw.cs
+++ b/2D SPH/Assets/Scripts/Runtime/Draw.cs
@@ -32,7 +32,7 @@ public class Draw : MonoBehaviour
     [SerializeField] float chequerFrequency;
     
     [Header("Marching cubes")]
-    [SerializeField] float isoLevel = 5;
+    [SerializeField] float isoLevel = 1;
     [SerializeField] Color fluidColour;
 
     [Header("Volumetric rays")]
@@ -283,7 +283,7 @@ public class Draw : MonoBehaviour
 
         if (drawMethod == DrawMethod.Rays)
         {
-            rays.RenderToCube(densityThreshold * restDensity);
+            rays.RenderToCube(densityTex, densityThreshold * restDensity);
         }
     }
 
@@ -310,10 +310,5 @@ public class Draw : MonoBehaviour
     {
         BindPositions(positionBuffer);
         BindColours(colourBuffer);
-    }
-
-    public void BindTexture(RenderTexture densityTex)
-    {
-        rays.BindTexture(densityTex);
     }
 }

--- a/2D SPH/Assets/Scripts/Runtime/Simulate.cs
+++ b/2D SPH/Assets/Scripts/Runtime/Simulate.cs
@@ -139,8 +139,6 @@ public class Simulate : MonoBehaviour
         UpdateMouseForce(Vector3.zero, 0, 0);
         UpdateVariables();
         UpdateBoundary();
-
-        drawer.BindTexture(densityTex);
     }
 
     void UpdateVariables()


### PR DESCRIPTION
Closes #367 

Texture wasn't being bound to the rays object if density texture resolution changed. Fix was to treat rays the same as cubes and give it all the information explicitly in the draw call